### PR TITLE
Update ToC to 7.0 and removed quickly.lua

### DIFF
--- a/Interface/AddOns/nCore/nCore.toc
+++ b/Interface/AddOns/nCore/nCore.toc
@@ -1,4 +1,4 @@
-## Interface: 60200
+## Interface: 70000
 ## Title: |cffCC3333 n|rCore
 ## OptionalDeps: !Beautycase, Recount, Omen, DBM, PitBull4, Skada, TinyDPS
 
@@ -13,7 +13,6 @@ modules\errors.lua
 modules\fonts.lua
 modules\mail.lua
 modules\objectivetracker.lua
-modules\quicky.lua
 modules\skins.lua
 modules\spellid.lua
 modules\warning.lua


### PR DESCRIPTION
Update to 7.0 and remove quickly.lua because you can now only hide helm, shoulder (new), and back at the transmog npc (no cost).