### PR TITLE
Hide editbox on login

### DIFF
--- a/Interface/AddOns/nChat/core.lua
+++ b/Interface/AddOns/nChat/core.lua
@@ -340,6 +340,9 @@ local function ModChat(self)
 
     _G[self..'EditBox']:SetAltArrowKeyMode(false)
 
+	-- Hide editbox on login
+	_G[self..'EditBox']:Hide()
+
     if (cfg.showInputBoxAbove) then
         _G[self..'EditBox']:ClearAllPoints()
         _G[self..'EditBox']:SetPoint('BOTTOMLEFT', GeneralDockManager, 'TOPLEFT', 2, 5)


### PR DESCRIPTION
This should fix the edit box not hiding upon login unless you intended for it to be this way?