### PR TITLE
Update to Kill.lua

### DIFF
--- a/Interface/AddOns/oUF_Neav/kill.lua
+++ b/Interface/AddOns/oUF_Neav/kill.lua
@@ -1,22 +1,11 @@
-
-    -- kill the config entry with stuff like 'show arena background' or 'bigger focustarget'
-
-InterfaceOptionsFrameCategoriesButton10:SetScale(0.00001)
-InterfaceOptionsFrameCategoriesButton10:SetAlpha(0)
-
-    -- kill the unitframestuff and 'remove' the playerframe animation functions
+-- Kill Unused Options
 
 for _, button in pairs({
-    'CombatPanelTargetOfTarget',
-    --'CombatPanelTOTDropDown',
-    --'CombatPanelTOTDropDownButton',
-    'CombatPanelEnemyCastBarsOnPortrait',
-
-    'DisplayPanelShowAggroPercentage',
-    --'DisplayPanelemphasizeMySpellEffects'
+    'CombatPanelTargetOfTarget', -- Target of Target
+    'DisplayPanelDisplayDropDown', -- Unit Frame Status Text
 }) do
-    _G['InterfaceOptions'..button]:SetAlpha(0.35)
-    _G['InterfaceOptions'..button]:Disable()
+    _G['InterfaceOptions'..button]:SetAlpha(0)
+    _G['InterfaceOptions'..button]:SetScale(0.00001)
     _G['InterfaceOptions'..button]:EnableMouse(false)
 end
 
@@ -26,6 +15,3 @@ function PlayerFrame_AnimateOut() end
 function PlayerFrame_AnimFinished() end
 function PlayerFrame_ToPlayerArt() end
 function PlayerFrame_ToVehicleArt() end
-
--- InterfaceOptionsFrameCategoriesButton9:SetScale(0.00001)
--- InterfaceOptionsFrameCategoriesButton9:SetAlpha(0)


### PR DESCRIPTION
1) Clear out all old unused interface options.
2) Hide Target of Target and Unit Frame Status Text Dropdown.

I went with setting the alpha and scale code that way it prevents empty spots in the interface options and avoids any unexpected interactions (the dropdown on the status text dropdown could still be clicked using Disable()).