### PR TITLE
Override default button.stealable SetPoint

### DIFF
--- a/Interface/AddOns/oUF_Neav/func/aura.lua
+++ b/Interface/AddOns/oUF_Neav/func/aura.lua
@@ -145,6 +145,12 @@ ns.UpdateAuraIcons = function(auras, button)
             button.Shadow:SetVertexColor(0, 0, 0, 1)
         end
 
+        if (button.stealable) then
+            local stealable = button:CreateTexture(nil, 'OVERLAY')
+            stealable:SetPoint('TOPLEFT', -4, 4)
+            stealable:SetPoint('BOTTOMRIGHT', 4, -4)
+        end
+        
         button.overlay.Hide = function(self)
             self:SetVertexColor(0.5, 0.5, 0.5, 1)
         end


### PR DESCRIPTION
Overrides the default position of the spellsteal texture to make it more visible. Issue #44

http://imgur.com/zUGVvYO