### PR TITLE
Focus frame disableAura and debffsOnly Options

### DIFF
--- a/Interface/AddOns/oUF_Neav/config.lua
+++ b/Interface/AddOns/oUF_Neav/config.lua
@@ -189,6 +189,8 @@ ns.Config = {
             scale = 1.193,
 
             numDebuffs = 6,
+            disableAura = false,
+            debuffsOnly = false,
 
             mouseoverText = false,
             healthTag = '$cur - $perc',


### PR DESCRIPTION
Focus frame options to show/hide aura icons and to only show debuffs. #45