### PR TITLE
Fix to PvPTimer showing 0

### DIFF
--- a/Interface/AddOns/oUF_Neav/tags.lua
+++ b/Interface/AddOns/oUF_Neav/tags.lua
@@ -22,7 +22,7 @@ oUF.Tags.Methods['druidmana'] = function(unit)
 end
 
 oUF.Tags.Methods['pvptimer'] = function(unit)
-    if (not IsPVPTimerRunning() and GetPVPTimer() >= 0) then
+    if (not IsPVPTimerRunning()) then
         return ''
     end
 


### PR DESCRIPTION
GetPVPTimer() isn't needed and sometimes would cause the UI to show 0 until something reset the timer. This was caused by GetPVPTimer() due the fact that it doesn't return 0 when the player isn't marked for pvp. If the UI update came at the wrong moment it would get stuck on 0 instead of showing nothing.