### PR TITLE
Set raid frame strata to low.

### DIFF
--- a/Interface/AddOns/oUF_NeavRaid/core.lua
+++ b/Interface/AddOns/oUF_NeavRaid/core.lua
@@ -823,5 +823,6 @@ oUF:Factory(function(self)
         end
 
         raid[i]:SetScale(config.units.raid.scale)
+        raid[i]:SetFrameStrata('LOW')
     end
 end)


### PR DESCRIPTION
This seems to be the only way to fix this and I checked and the default unit frames all use the low strata so it shouldn't cause any problems. We should also change the strata of the frames in oUF_Neav.