### PR TITLE
Fix of Colorz taint problem.

### DIFF
--- a/Interface/AddOns/!Colorz/!Colorz.lua
+++ b/Interface/AddOns/!Colorz/!Colorz.lua
@@ -1,7 +1,12 @@
+-- Sets manabar color for default unit frames.
+local function CustomManaColor(manaBar)
+	local powerType = UnitPowerType(manaBar.unit);
 
--- function SetUpAnimation(frame) CancelAnimations(frame) end
-
-_G.PowerBarColor['MANA'] = {r = 0/255, g = 0.55, b = 1}
+    if ( powerType == 0 ) then
+        manaBar:SetStatusBarColor(0,0.55,1)
+    end
+end
+hooksecurefunc('UnitFrameManaBar_UpdateType',CustomManaColor)
 
 CUSTOM_FACTION_BAR_COLORS = {
     [1] = {r = 1, g = 0, b = 0},
@@ -15,6 +20,7 @@ CUSTOM_FACTION_BAR_COLORS = {
 }
 
 function GameTooltip_UnitColor(unit)
+
     local r, g, b
 
     if (UnitIsDead(unit) or UnitIsGhost(unit) or UnitIsTapDenied(unit)) then
@@ -24,9 +30,13 @@ function GameTooltip_UnitColor(unit)
     elseif (UnitIsPlayer(unit)) then
         if (UnitIsFriend(unit, 'player')) then
             local _, class = UnitClass(unit)
-            r = RAID_CLASS_COLORS[class].r
-            g = RAID_CLASS_COLORS[class].g
-            b = RAID_CLASS_COLORS[class].b
+            if ( class ) then
+                r = RAID_CLASS_COLORS[class].r
+                g = RAID_CLASS_COLORS[class].g
+                b = RAID_CLASS_COLORS[class].b
+            else
+                r = 0.60, g = 0.60, b = 0.60
+            end
         elseif (not UnitIsFriend(unit, 'player')) then
             r = 1
             g = 0

--- a/Interface/AddOns/nPower/core.lua
+++ b/Interface/AddOns/nPower/core.lua
@@ -241,11 +241,15 @@ local function UpdateBarValue()
 end
 
 local function UpdateBarColor()
-    local _, powerType, altR, altG, altB = UnitPowerType('player')
-    local unitPower = PowerBarColor[powerType]
+    local powerType, powerToken, altR, altG, altB = UnitPowerType('player')
+    local unitPower = PowerBarColor[powerToken]
 
     if (unitPower) then
-        f.Power:SetStatusBarColor(unitPower.r, unitPower.g, unitPower.b)
+        if ( powerType == 0 ) then
+            f.Power:SetStatusBarColor(0,0.55,1)
+        else
+            f.Power:SetStatusBarColor(unitPower.r, unitPower.g, unitPower.b)
+        end
     else
         f.Power:SetStatusBarColor(altR, altG, altB)
     end

--- a/Interface/AddOns/oUF_Neav/core.lua
+++ b/Interface/AddOns/oUF_Neav/core.lua
@@ -7,6 +7,9 @@ local charTexPath = 'Interface\\CharacterFrame\\'
 local tarTexPath = 'Interface\\TargetingFrame\\'
 local texPath = tarTexPath..'UI-TargetingFrame'
 
+local oUF = ns.oUF or oUF
+oUF.colors.power["MANA"] = {0,0.55,1}
+
 local texTable = {
     ['elite'] = texPath..'-Elite',
     ['rareelite'] = texPath..'-Rare-Elite',

--- a/Interface/AddOns/oUF_NeavRaid/core.lua
+++ b/Interface/AddOns/oUF_NeavRaid/core.lua
@@ -2,6 +2,9 @@
 local _, ns = ...
 local config = ns.Config
 
+local oUF = ns.oUF or oUF
+oUF.colors.power["MANA"] = {0,0.55,1}
+
 local playerClass = select(2, UnitClass('player'))
 
     -- oUF_AuraWatch


### PR DESCRIPTION
Drops setting the mana color directly because that what was causing the
taint issues.

1) New code to set the custom mana color to the default unit frames.
2) Set the mana color in oUF_Neav and oUF_NeavRaid by changing the oUF
table instead of Blizzards.
3) Hardcode the mana color for nPower.
4) Fallback color for RAID_CLASS_COLORS incase the game fails to
properly retrieve class.