### PR TITLE
Fix Rogue action bars not switching in combat.

### DIFF
--- a/Interface/AddOns/nMainbar/modules/stancebar.lua
+++ b/Interface/AddOns/nMainbar/modules/stancebar.lua
@@ -9,9 +9,8 @@ StanceBarFrame:SetAlpha(cfg.stanceBar.alpha)
 
 if (cfg.stanceBar.hide) then
     hooksecurefunc("StanceBar_Update", function()
-        if StanceBarFrame:IsShown() then
+        if StanceBarFrame:IsShown() and not InCombatLockdown() then
             RegisterStateDriver(StanceBarFrame, "visibility", "hide")
-            function StanceBar_Update() end
         end
     end)
 end


### PR DESCRIPTION
Add a check for combat and drop overriding the StanceBar_Update function.